### PR TITLE
[codex] Fix StackingDAO get-dy scaled fees

### DIFF
--- a/contracts/stableswap-stackingDAO.clar
+++ b/contracts/stableswap-stackingDAO.clar
@@ -247,7 +247,7 @@
             (x-amount-fees-lps-scaled (/ (* x-amount-scaled swap-fee-lps) u10000))
             (x-amount-fees-stacking-dao-scaled (/ (* x-amount-scaled swap-fee-stacking-dao) u10000))
             (x-amount-fees-bitflow-scaled (/ (* x-amount-scaled swap-fee-bitflow) u10000))
-            (x-amount-total-fees-scaled (/ (* x-amount total-swap-fee) u10000))
+            (x-amount-total-fees-scaled (/ (* x-amount-scaled total-swap-fee) u10000))
             (updated-x-amount-scaled (- x-amount-scaled x-amount-total-fees-scaled))
             (updated-x-balance-scaled (+ current-balance-x-scaled updated-x-amount-scaled))
             (new-y-scaled (get-y updated-x-balance-scaled current-balance-y-scaled updated-x-amount-scaled (* (get amplification-coefficient pair-data) number-of-tokens)))

--- a/tests/stableswap-stackingDAO_test.ts
+++ b/tests/stableswap-stackingDAO_test.ts
@@ -160,6 +160,56 @@ Clarinet.test({
     },
 });
 
+// Test get-dy for a pair where x and y token decimals differ
+Clarinet.test({
+    name: "Ensure get-dy matches swap output for mixed-decimal pairs",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get("deployer")!;
+        const yToken = `${deployer.address}.susdt-token`;
+        const lpToken = `${deployer.address}.usda-susdt-lp-token`;
+        const stableswapStackingDao = `${deployer.address}.stableswap-stackingDAO`;
+        const initialX = 1000000000;
+        const initialY = 100000000000;
+        const xAmount = 10000000;
+
+        chain.mineBlock([
+            Tx.contractCall("susdt-token", "mint", [types.uint(200000000000), types.principal(deployer.address)], deployer.address),
+            Tx.contractCall("usda-susdt-lp-token", "set-supply-controller", [types.principal(stableswapStackingDao)], deployer.address),
+        ]);
+
+        const createPair = chain.mineBlock([
+            Tx.contractCall("stableswap-stackingDAO", "create-pair", [
+                types.principal(yToken),
+                types.principal(lpToken),
+                types.uint(100),
+                types.ascii("test-susdt"),
+                types.uint(initialX),
+                types.uint(initialY),
+            ], deployer.address),
+        ]);
+        createPair.receipts[0].result.expectOk();
+
+        const quote = chain.callReadOnlyFn("stableswap-stackingDAO", "get-dy", [
+            types.principal(yToken),
+            types.principal(lpToken),
+            types.uint(xAmount),
+        ], deployer.address);
+
+        const block = chain.mineBlock([
+            Tx.contractCall("stableswap-stackingDAO", "swap-x-for-y", [
+                types.principal(yToken),
+                types.principal(lpToken),
+                types.uint(xAmount),
+                types.uint(0),
+            ], deployer.address),
+        ]);
+
+        const quotedDy = quote.result.expectOk();
+        const swappedDy = block.receipts[0].result.expectOk();
+        assertEquals(swappedDy, quotedDy);
+    },
+});
+
 
 // Test swap x for y
 Clarinet.test({


### PR DESCRIPTION
## Summary
- Apply the total swap fee to `x-amount-scaled` inside `stableswap-stackingDAO.get-dy`.
- Keep the read-only quote path aligned with `swap-x-for-y`, which already computes fees in scaled units before deriving `dy`.
- Add a mixed-decimal regression case using 6-decimal STX input and 8-decimal sUSDT output so `get-dy` must match the actual swap return.

## Audit context
This addresses ClankOS StackingDAO audit finding F-04 from https://gist.github.com/ClankOS/61003f54ed834fdbc9be72fe95a314fa. The finding notes that `get-dy` scales `x-amount` but then computes total fees from the unscaled `x-amount`, producing inaccurate quotes for pairs whose token decimals differ.

## Validation
- `git diff --check`
- `clarinet check` with 12 contracts checked; remaining warnings are pre-existing project warnings
- Clarinet console mixed-decimal scenario: `get-dy` returned `(ok u999303143)` and `swap-x-for-y` returned `(ok u999303143)` for the same 6-decimal STX -> 8-decimal sUSDT swap

BTC payout address if this is accepted for any related bounty: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
