### PR TITLE
[codex] Reject zero StackingDAO convergence threshold

### DIFF
--- a/contracts/stableswap-stackingDAO.clar
+++ b/contracts/stableswap-stackingDAO.clar
@@ -1063,6 +1063,7 @@
         )
         ;; Assert that tx-sender is an admin using is-some & index-of with the admins var
         (asserts! (is-some (index-of current-admins tx-sender)) (err "err-not-admin"))
+        (asserts! (> new-convergence-threshold u0) (err "err-invalid-convergence-threshold"))
 
         (ok (var-set convergence-threshold new-convergence-threshold))
     )

--- a/tests/stableswap-stackingDAO_test.ts
+++ b/tests/stableswap-stackingDAO_test.ts
@@ -1607,3 +1607,35 @@ Clarinet.test({
         console.log(JSON.stringify(block.receipts));
     },
 });
+
+// Test convergence threshold admin controls
+Clarinet.test({
+    name: "Ensure admins cannot set convergence threshold to zero",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get("deployer")!;
+        const wallet_1 = accounts.get("wallet_1")!;
+
+        const block = chain.mineBlock([
+            Tx.contractCall("stableswap-stackingDAO", "change-convergence-threshold", [types.uint(0)], deployer.address)
+        ]);
+
+        block.receipts[0].result.expectErr()
+        console.log(JSON.stringify(block.receipts));
+    },
+});
+
+// Test convergence threshold admin controls
+Clarinet.test({
+    name: "Ensure admins can set convergence threshold above zero",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get("deployer")!;
+        const wallet_1 = accounts.get("wallet_1")!;
+
+        const block = chain.mineBlock([
+            Tx.contractCall("stableswap-stackingDAO", "change-convergence-threshold", [types.uint(1)], deployer.address)
+        ]);
+
+        block.receipts[0].result.expectOk()
+        console.log(JSON.stringify(block.receipts));
+    },
+});


### PR DESCRIPTION
## Summary
- Reject `change-convergence-threshold u0` in the StackingDAO stableswap contract.
- Keep positive convergence thresholds accepted.
- Add regression coverage for the zero-threshold rejection and a positive-threshold success case.

## Audit context
This addresses F-06 from the public ClankOS / AIBTC StackingDAO stableswap audit notes:
https://gist.github.com/ClankOS/61003f54ed834fdbc9be72fe95a314fa

The convergence loops check whether the Newton-Raphson delta is less than or equal to the configured threshold. Allowing an admin to set that threshold to `u0` removes the tolerance and can prevent convergence under normal integer rounding, which can cascade into `get-D` returning `u0` and later pool operations panicking. This PR rejects `u0` at the setter boundary.

## Validation
- `git diff --check`
- `clarinet check` passes for all 12 contracts; existing repository warnings remain.
- Manual Clarinet console checks:
  - `change-convergence-threshold u0` returns `(err "err-invalid-convergence-threshold")`.
  - `change-convergence-threshold u1` returns `(ok true)`.
