### PR TITLE
[codex] Reject zero standard stableswap convergence threshold

### DIFF
--- a/contracts/stableswap.clar
+++ b/contracts/stableswap.clar
@@ -1005,6 +1005,7 @@
         )
         ;; Assert that tx-sender is an admin using is-some & index-of with the admins var
         (asserts! (is-some (index-of current-admins tx-sender)) (err "err-not-admin"))
+        (asserts! (> new-convergence-threshold u0) (err "err-invalid-convergence-threshold"))
 
         (ok (var-set convergence-threshold new-convergence-threshold))
     )
@@ -1032,4 +1033,3 @@
         (ok staking-contract)
     )
 )
-

--- a/tests/stableswap_test.ts
+++ b/tests/stableswap_test.ts
@@ -1676,3 +1676,35 @@ Clarinet.test({
         console.log(JSON.stringify(block.receipts));
     },
 });
+
+// Test convergence threshold admin controls
+Clarinet.test({
+    name: "Ensure admins cannot set convergence threshold to zero",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get("deployer")!;
+        const wallet_1 = accounts.get("wallet_1")!;
+
+        const block = chain.mineBlock([
+            Tx.contractCall("stableswap", "change-convergence-threshold", [types.uint(0)], deployer.address)
+        ]);
+
+        block.receipts[0].result.expectErr()
+        console.log(JSON.stringify(block.receipts));
+    },
+});
+
+// Test convergence threshold admin controls
+Clarinet.test({
+    name: "Ensure admins can set convergence threshold above zero",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get("deployer")!;
+        const wallet_1 = accounts.get("wallet_1")!;
+
+        const block = chain.mineBlock([
+            Tx.contractCall("stableswap", "change-convergence-threshold", [types.uint(1)], deployer.address)
+        ]);
+
+        block.receipts[0].result.expectOk()
+        console.log(JSON.stringify(block.receipts));
+    },
+});


### PR DESCRIPTION
## Summary
- reject `change-convergence-threshold u0` in the standard stableswap contract
- keep positive threshold updates unchanged
- add regression coverage for the rejected zero path and accepted positive path

## Why
A zero convergence threshold removes the tolerance used by the iterative stable-swap solvers, which can make convergence behavior brittle or unreachable. The StackingDAO stableswap path now rejects this value; the standard stableswap path should apply the same guard.

## Validation
- `git diff --check`
- `clarinet check`
- `clarinet console` confirmed `(err "err-invalid-convergence-threshold")` for `u0` and `(ok true)` for `u1`

Note: the local environment does not have `deno`, so the TypeScript Clarinet tests were added but not executed here.