### PR TITLE
[codex] Fix standard stableswap quote fee scaling

### DIFF
--- a/contracts/stableswap.clar
+++ b/contracts/stableswap.clar
@@ -151,7 +151,7 @@
             (y-amount-scaled (get scaled-y scaled-up-swap-amount))
             (y-amount-fees-lps-scaled (/ (* y-amount-scaled swap-fee-lps) u10000))
             (y-amount-fees-protocol-scaled (/ (* y-amount-scaled swap-fee-protocol) u10000))
-            (y-amount-total-fees-scaled (/ (* y-amount total-swap-fee) u10000))
+            (y-amount-total-fees-scaled (/ (* y-amount-scaled total-swap-fee) u10000))
             (updated-y-amount-scaled (- y-amount-scaled y-amount-total-fees-scaled))
             (updated-y-balance-scaled (+ current-balance-y-scaled updated-y-amount-scaled))
             (new-x-scaled (get-x updated-y-balance-scaled current-balance-x-scaled updated-y-amount-scaled (* (get amplification-coefficient pair-data) number-of-tokens)))
@@ -239,7 +239,7 @@
             (x-amount-scaled (get scaled-x scaled-up-swap-amount))
             (x-amount-fees-lps-scaled (/ (* x-amount-scaled swap-fee-lps) u10000))
             (x-amount-fees-protocol-scaled (/ (* x-amount-scaled swap-fee-protocol) u10000))
-            (x-amount-total-fees-scaled (/ (* x-amount total-swap-fee) u10000))
+            (x-amount-total-fees-scaled (/ (* x-amount-scaled total-swap-fee) u10000))
             (updated-x-amount-scaled (- x-amount-scaled x-amount-total-fees-scaled))
             (updated-x-balance-scaled (+ current-balance-x-scaled updated-x-amount-scaled))
             (new-y-scaled (get-y updated-x-balance-scaled current-balance-y-scaled updated-x-amount-scaled (* (get amplification-coefficient pair-data) number-of-tokens)))
@@ -1032,4 +1032,3 @@
         (ok staking-contract)
     )
 )
-

--- a/tests/stableswap_test.ts
+++ b/tests/stableswap_test.ts
@@ -678,6 +678,35 @@ Clarinet.test({
     },
 });
 
+// Test get-dx returns the same amount as swap-y-for-x for mixed-decimal pairs
+Clarinet.test({
+    name: "Ensure get-dx matches swap-y-for-x after scaled fees",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get("deployer")!;
+
+        chain.mineBlock([
+            Tx.contractCall("usda-token", "mint", [types.uint(100000000000000), types.principal(deployer.address)], deployer.address)
+        ]);
+
+        chain.mineBlock([
+            Tx.contractCall("susdt-token", "mint", [types.uint(10000000000000000), types.principal(deployer.address)], deployer.address)
+        ]);
+
+        chain.mineBlock([
+            Tx.contractCall("stableswap", "create-pair", [types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.susdt-token"), types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.usda-token"), types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.usda-susdt-lp-token"), types.uint(100), types.ascii("test"), types.uint(1000000000000000), types.uint(10000000000000)], deployer.address)
+        ]);
+
+        const quote = chain.callReadOnlyFn("stableswap", "get-dx", [types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.usda-token"), types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.susdt-token"), types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.usda-susdt-lp-token"), types.uint(100000000)], deployer.address);
+
+        const block = chain.mineBlock([
+            Tx.contractCall("stableswap", "swap-y-for-x", [types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.usda-token"), types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.susdt-token"), types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.usda-susdt-lp-token"), types.uint(100000000), types.uint(0)], deployer.address)
+        ]);
+
+        quote.result.expectOk().expectUint(9994998022);
+        block.receipts[0].result.expectOk().expectUint(9994998022);
+    },
+});
+
 
 // Test swap y for x 9 times and get the same amount
 Clarinet.test({


### PR DESCRIPTION
## Summary
- calculate `get-dx` and `get-dy` total swap fees from scaled token amounts
- add a mixed-decimal regression test that checks `get-dx` against `swap-y-for-x`

## Why
The read-only quote helpers compute AMM balances in scaled precision, but their total-fee inputs used the unscaled token amount. For mixed-decimal pairs this can make the quote path diverge from the executable swap path. In the USDA/sUSDT pool, `get-dx` overquoted `u9999948020` before the fix while `swap-y-for-x` returned `u9994998022` for the same `u100000000` USDA input.

## Validation
- `git diff --check`
- `clarinet check`
- `clarinet console` confirmed `get-dx` and `swap-y-for-x` now both return `u9994998022` for the mixed-decimal scenario above

Note: the local environment does not have `deno`, so the TypeScript Clarinet test was added but not executed here.